### PR TITLE
fix strcmp's logic for return values

### DIFF
--- a/lib/c.c
+++ b/lib/c.c
@@ -33,7 +33,7 @@ int strcmp(char *s1, char *s2)
             return 1;
         i++;
     }
-    return s2[i] - s1[i];
+    return s1[i] - s2[i];
 }
 
 int strncmp(char *s1, char *s2, int len)


### PR DESCRIPTION
original implementation didn't follow the rule of classic
strcmp.