### PR TITLE
Fix incorrect encoding of CMP

### DIFF
--- a/src/arm.c
+++ b/src/arm.c
@@ -256,9 +256,9 @@ int __rsb_i(arm_cond_t cond, arm_reg rd, int imm, arm_reg rn)
     return __mov(cond, 1, arm_rsb, 0, rd, rn, imm);
 }
 
-int __cmp_r(arm_cond_t cond, arm_reg rd, arm_reg r1, arm_reg r2)
+int __cmp_r(arm_cond_t cond, arm_reg r1, arm_reg r2)
 {
-    return __mov(cond, 0, arm_cmp, 1, r1, rd, r2);
+    return __mov(cond, 0, arm_cmp, 1, r1, 0, r2);
 }
 
 int __teq(arm_reg rd)

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -376,7 +376,7 @@ void code_generate()
         case OP_gt:
         case OP_geq:
             /* we want 1/nonzero if equ, 0 otherwise */
-            emit(__cmp_r(__AL, dest_reg, dest_reg, OP_reg));
+            emit(__cmp_r(__AL, dest_reg, OP_reg));
             emit(__zero(dest_reg));
             emit(__mov_i(arm_get_cond(op), dest_reg, 1));
 


### PR DESCRIPTION
Fix #4 

We can see the following crash by running Shecc at qemu 5.1.0

	qemu: uncaught target signal 4 (Illegal instruction) - core dumped

The illegal instruction is due to incorrect machine code of CMP
	1d604: e1511002  cmp r1, r2

According to `ARM Architecture Reference Manual ARMv7-A and ARMv7-R`,
the bit<15:12> is 0000, but Shecc encoded as 0001.

The rd in __cmp_r() endcoded as (rd << 12) and, actually,
no one uses rd and disobey the specification.

After Qemu 4.1.0,

https://lore.kernel.org/qemu-devel/20190904193059.26202-1-richard.henderson@linaro.org/

A strict encoding checker was introduced at target/arm/a32.decode,
and the CMP (register) should be:

CMP_xrrr         .... 000 1010 1 .... 0000 .... 0 .. 1 ....
                                      |  |
                                     15  12

That is, the bit<15:12> must be 0000.

Fix this by droping argument rd in __cmp_r().