### PR TITLE
Support global variable initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,8 +165,7 @@ int fib(int n)      fib:                        Reserve stack frame for function
 
 1. Any non-zero value is NOT treated as logical truth by all ops.
    That is, the expression `0 == strcmp(ptr, "hello")` is not equivalent to `!strcmp(ptr, "hello")`.
-2. Global variable initialization is not supported. 
-   Therefore, you can not initialize a global such as `int i = [expr]`.
+2. The generated ELF lacks of .bss and .rodata section
 3. Dereference is incomplete. Consider `int x = 5; int *ptr = &x;` and it is forbidden to use `*ptr`.
    However, it is valid to use `ptr[0]`, which behaves the same of `*ptr`.
 4. The support of varying number of function arguments is incomplete. No `<stdarg.h>` can be used.

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -75,7 +75,12 @@ void size_funcs(int data_start)
         blk->locals[i].offset = elf_data_idx; /* set offset in data section */
         elf_add_symbol(blk->locals[i].var_name, strlen(blk->locals[i].var_name),
                        data_start + elf_data_idx);
-        elf_data_idx += size_var(&blk->locals[i]);
+        /* TODO: add .bss section */
+        if (strcmp(blk->locals[i].type_name, "int") == 0 &&
+            blk->locals[i].init_val != 0)
+            elf_write_data_int(blk->locals[i].init_val);
+        else
+            elf_data_idx += size_var(&blk->locals[i]);
     }
 }
 

--- a/src/defs.h
+++ b/src/defs.h
@@ -106,7 +106,8 @@ typedef struct {
     char var_name[MAX_VAR_LEN];
     int is_ptr;
     int array_size;
-    int offset; /* offset from stack or frame */
+    int offset;   /* offset from stack or frame */
+    int init_val; /* for global initialization */
 } var_t;
 
 /* function definition */

--- a/src/elf.c
+++ b/src/elf.c
@@ -19,6 +19,14 @@ void elf_write_data_str(char *vals, int len)
         elf_data[elf_data_idx++] = vals[i];
 }
 
+void elf_write_data_int(int val)
+{
+    elf_data[elf_data_idx++] = (val & 0x000000FF);
+    elf_data[elf_data_idx++] = (val & 0x0000FF00) >> 8;
+    elf_data[elf_data_idx++] = (val & 0x00FF0000) >> 16;
+    elf_data[elf_data_idx++] = (val & 0xFF000000) >> 24;
+}
+
 void elf_write_header_byte(int val)
 {
     elf_header[elf_header_idx++] = val;

--- a/tests/driver.sh
+++ b/tests/driver.sh
@@ -247,6 +247,16 @@ int main() {
 }
 EOF
 
+# global initialization
+try_ 20 << EOF
+int a = 5 * 2;
+int b = -4 * 3 + 7 + 9 / 3 * 5;
+int main()
+{
+    exit(a + b);
+}
+EOF
+
 # conditional operator
 # expr 10 "1 ? 10 : 5"
 # expr 25 "0 ? 10 : 25"


### PR DESCRIPTION
In latest version, there already have .data section which is for storing **initialized global variable**. As a result, I don't add .bss section which is for uninitialized variable in this pull request.