### PR TITLE
Eliminate compilation warnings

### DIFF
--- a/src/cfront.c
+++ b/src/cfront.c
@@ -1329,7 +1329,7 @@ int read_numeric_sconstant()
 int eval_expression_imm(opcode_t op, int op1, int op2)
 {
     /* return immediate result */
-    int res;
+    int res = 0;
     switch (op) {
     case OP_add:
         res = op1 + op2;


### PR DESCRIPTION
To solve `warning: variable 'res' is used uninitialized whenever switch default is taken [-Wsometimes-uninitialized].`

How about this PR?
I just wanna use clang to compile the project without warning.