### PR TITLE
Rework malloc and free function

### DIFF
--- a/lib/c.c
+++ b/lib/c.c
@@ -370,12 +370,81 @@ int fputc(int c, FILE *stream)
  * FIXME: adopt lite_malloc from musl-libc
  *   https://git.musl-libc.org/cgit/musl/tree/src/malloc/lite_malloc.c
  */
-void *malloc(int size)
+
+typedef struct block_meta {
+    int size;
+    struct block_meta *next;
+    int free;
+} block_meta_t;
+
+block_meta_t *__malloc_global_base;
+block_meta_t *__malloc_global_last;
+
+block_meta_t *__malloc_request_space(int size)
 {
-    char *brk = __syscall(__syscall_brk, 0); /* read current break */
-    char *request = __syscall(__syscall_brk, brk + size);
+    char *brk;
+    block_meta_t *block;
+    brk = __syscall(__syscall_brk, 0);
+    block = brk;
+
+    char *request =
+        __syscall(__syscall_brk, block + size + sizeof(block_meta_t));
     if (request == -1)
         return NULL;
-    /* return previous location, now extended by size */
-    return brk;
+
+    if (__malloc_global_last != NULL)
+        __malloc_global_last->next = block;
+
+    block->size = size;
+    block->next = NULL;
+    block->free = 0;
+    return block;
+}
+
+void *malloc(int size)
+{
+    block_meta_t *block;
+    if (size == 0)
+        return NULL;
+    if (__malloc_global_base == NULL) {
+        block = __malloc_request_space(size);
+        if (block == NULL)
+            return NULL;
+        __malloc_global_base = block;
+    } else {
+        block_meta_t *current = __malloc_global_base;
+        __malloc_global_last = __malloc_global_base;
+        while (current != NULL) {
+            /* TODO: support break in while loop */
+            if (current->free == 1 && current->size >= size)
+                return current + 1;
+            __malloc_global_last = current;
+            current = current->next;
+        }
+        block = current;
+        if (block == NULL) {
+            block = __malloc_request_space(size);
+            if (block == NULL)
+                return NULL;
+        } else {
+            /* TODO: use the size requested instead of whole blocks */
+            block->free = 0;
+        }
+    }
+    return block + 1;
+}
+
+/* Quoting the C standard, 7.20.3.2/2 from ISO-IEC 9899:
+ * "If ptr is a null pointer, no action occurs."
+ */
+void free(void *ptr)
+{
+    if (ptr == NULL)
+        return;
+
+    /* TODO: merge several free memory blocks */
+    block_meta_t *block_ptr = ptr - sizeof(block_meta_t);
+    if (block_ptr->free == 1)
+        abort();
+    block_ptr->free = 1;
 }

--- a/tests/driver.sh
+++ b/tests/driver.sh
@@ -280,4 +280,20 @@ typedef enum { enum1 = 5, enum2 } enum_t;
 int main() { enum_t v = enum2; exit(v); }
 EOF
 
+# malloc and free
+try_ 1 << EOF
+int main()
+{
+    /* change test bench if different scheme apply */
+    int *a = malloc(sizeof(int) * 5);
+    free(a);
+    if (a == NULL)
+        abort();
+    int *b = malloc(sizeof(int) * 3);
+
+    /* "malloc" will reuse memory free'd by "free(a)" */
+    exit(a == b);
+}
+EOF
+
 echo OK


### PR DESCRIPTION
Rewrite "malloc" and add "free" function.
Import new data structure "block_meta_t"
to record extra information. 

Scheme for memory reuse in this patch is naive, just reuse whole block.
I'll implement better algorithm in future (e.g. split free block).

Corresponding example is tests/malloc_and_free.c