### PR TITLE
Clean up the comparison with zero

### DIFF
--- a/lib/c.c
+++ b/lib/c.c
@@ -315,9 +315,9 @@ void abort()
 
 FILE *fopen(char *filename, char *mode)
 {
-    if (strcmp(mode, "wb") == 0)
+    if (!strcmp(mode, "wb"))
         return __syscall(__syscall_open, filename, 65, 0x1fd);
-    if (strcmp(mode, "rb") == 0)
+    if (!strcmp(mode, "rb"))
         return __syscall(__syscall_open, filename, 0, 0);
     abort();
 }
@@ -392,7 +392,7 @@ block_meta_t *__malloc_request_space(int size)
     if (request == -1)
         return NULL;
 
-    if (__malloc_global_last != NULL)
+    if (__malloc_global_last)
         __malloc_global_last->next = block;
 
     block->size = size;
@@ -406,15 +406,15 @@ void *malloc(int size)
     block_meta_t *block;
     if (size == 0)
         return NULL;
-    if (__malloc_global_base == NULL) {
+    if (!__malloc_global_base) {
         block = __malloc_request_space(size);
-        if (block == NULL)
+        if (!block)
             return NULL;
         __malloc_global_base = block;
     } else {
         block_meta_t *current = __malloc_global_base;
         __malloc_global_last = __malloc_global_base;
-        while (current != NULL) {
+        while (current) {
             /* TODO: support break in while loop */
             if (current->free == 1 && current->size >= size)
                 return current + 1;
@@ -422,9 +422,9 @@ void *malloc(int size)
             current = current->next;
         }
         block = current;
-        if (block == NULL) {
+        if (!block) {
             block = __malloc_request_space(size);
-            if (block == NULL)
+            if (!block)
                 return NULL;
         } else {
             /* TODO: use the size requested instead of whole blocks */
@@ -439,7 +439,7 @@ void *malloc(int size)
  */
 void free(void *ptr)
 {
-    if (ptr == NULL)
+    if (!ptr)
         return;
 
     /* TODO: merge several free memory blocks */

--- a/src/cfront.c
+++ b/src/cfront.c
@@ -128,19 +128,18 @@ token_t get_next_token()
         token_str[i] = 0;
         skip_whitespace();
 
-        if (strcmp(token_str, "#include") == 0) {
-            i = 0;
+        if (!strcmp(token_str, "#include")) {
             do {
                 token_str[i++] = next_char;
             } while (read_char(0) != '\n');
             skip_whitespace();
             return T_include;
         }
-        if (strcmp(token_str, "#define") == 0) {
+        if (!strcmp(token_str, "#define")) {
             skip_whitespace();
             return T_define;
         }
-        if (strcmp(token_str, "#ifdef") == 0) {
+        if (!strcmp(token_str, "#ifdef")) {
             i = 0;
             do {
                 token_str[i++] = next_char;
@@ -148,7 +147,7 @@ token_t get_next_token()
             token_str[i] = 0;
             /* check if we have this alias/define */
             for (i = 0; i < aliases_idx; i++) {
-                if (strcmp(token_str, ALIASES[i].alias) == 0) {
+                if (!strcmp(token_str, ALIASES[i].alias)) {
                     skip_whitespace();
                     return get_next_token();
                 }
@@ -165,7 +164,7 @@ token_t get_next_token()
             skip_whitespace();
             return get_next_token();
         }
-        if (strcmp(token_str, "#endif") == 0) {
+        if (!strcmp(token_str, "#endif")) {
             skip_whitespace();
             return get_next_token();
         }
@@ -444,35 +443,35 @@ token_t get_next_token()
         token_str[i] = 0;
         skip_whitespace();
 
-        if (strcmp(token_str, "if") == 0)
+        if (!strcmp(token_str, "if"))
             return T_if;
-        if (strcmp(token_str, "while") == 0)
+        if (!strcmp(token_str, "while"))
             return T_while;
-        if (strcmp(token_str, "for") == 0)
+        if (!strcmp(token_str, "for"))
             return T_for;
-        if (strcmp(token_str, "do") == 0)
+        if (!strcmp(token_str, "do"))
             return T_do;
-        if (strcmp(token_str, "else") == 0)
+        if (!strcmp(token_str, "else"))
             return T_else;
-        if (strcmp(token_str, "return") == 0)
+        if (!strcmp(token_str, "return"))
             return T_return;
-        if (strcmp(token_str, "typedef") == 0)
+        if (!strcmp(token_str, "typedef"))
             return T_typedef;
-        if (strcmp(token_str, "enum") == 0)
+        if (!strcmp(token_str, "enum"))
             return T_enum;
-        if (strcmp(token_str, "struct") == 0)
+        if (!strcmp(token_str, "struct"))
             return T_struct;
-        if (strcmp(token_str, "sizeof") == 0)
+        if (!strcmp(token_str, "sizeof"))
             return T_sizeof;
-        if (strcmp(token_str, "switch") == 0)
+        if (!strcmp(token_str, "switch"))
             return T_switch;
-        if (strcmp(token_str, "case") == 0)
+        if (!strcmp(token_str, "case"))
             return T_case;
-        if (strcmp(token_str, "break") == 0)
+        if (!strcmp(token_str, "break"))
             return T_break;
-        if (strcmp(token_str, "default") == 0)
+        if (!strcmp(token_str, "default"))
             return T_default;
-        if (strcmp(token_str, "continue") == 0)
+        if (!strcmp(token_str, "continue"))
             return T_continue;
 
         alias = find_alias(token_str);
@@ -499,7 +498,7 @@ int lex_accept(token_t token)
 int lex_peek(token_t token, char *value)
 {
     if (next_token == token) {
-        if (value == NULL)
+        if (!value)
             return 1;
         strcpy(value, token_str);
         return 1;
@@ -798,7 +797,7 @@ void read_expr_operand(int param_no, block_t *parent)
         lex_expect(T_open_bracket);
         lex_indent(T_identifier, token);
         type = find_type(token);
-        if (type == NULL)
+        if (!type)
             error("Unable to find type");
 
         ii->param_no = param_no;
@@ -1269,7 +1268,7 @@ void read_lvalue(lvalue_t *lvalue,
 int read_body_assignment(char *token, block_t *parent, opcode_t prefix_op)
 {
     var_t *var = find_local_var(token, parent);
-    if (var == NULL)
+    if (!var)
         var = find_global_var(token);
     if (var) {
         ir_instr_t *ii;
@@ -1962,7 +1961,7 @@ void read_global_statement()
     block_t *block = &BLOCKS[0]; /* global block */
 
     if (lex_peek(T_include, token)) {
-        if (strcmp(token_str, "<stdio.h>") == 0) {
+        if (!strcmp(token_str, "<stdio.h>")) {
             /* ignore, we inclue libc by default */
         }
         lex_expect(T_include);
@@ -2023,7 +2022,7 @@ void read_global_statement()
             type_t *type = add_type();
             lex_indent(T_identifier, base_type);
             base = find_type(base_type);
-            if (base == NULL)
+            if (!base)
                 error("Unable to find base type");
             type->base_type = base->base_type;
             type->size = base->size;
@@ -2106,11 +2105,11 @@ void load_source_file(char *file)
 
     FILE *f = fopen(file, "rb");
     for (;;) {
-        if (fgets(buffer, MAX_LINE_LEN, f) == NULL) {
+        if (!fgets(buffer, MAX_LINE_LEN, f)) {
             fclose(f);
             return;
         }
-        if ((strncmp(buffer, "#include ", 9) == 0) && (buffer[9] == '"')) {
+        if (!strncmp(buffer, "#include ", 9) && (buffer[9] == '"')) {
             char path[MAX_LINE_LEN];
             int c = strlen(file) - 1;
             while (c > 0 && file[c] != '/')

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -28,7 +28,7 @@ int size_block(block_t *blk)
     int size = 0, i, offset;
 
     /* our offset starts from parent's offset */
-    if (blk->parent == NULL) {
+    if (!blk->parent) {
         if (blk->func)
             offset = blk->func->params_size;
         else
@@ -76,7 +76,7 @@ void size_funcs(int data_start)
         elf_add_symbol(blk->locals[i].var_name, strlen(blk->locals[i].var_name),
                        data_start + elf_data_idx);
         /* TODO: add .bss section */
-        if (strcmp(blk->locals[i].type_name, "int") == 0 &&
+        if (!strcmp(blk->locals[i].type_name, "int") &&
             blk->locals[i].init_val != 0)
             elf_write_data_int(blk->locals[i].init_val);
         else
@@ -240,7 +240,7 @@ void code_generate()
                 int offset;
                 /* need to find the variable offset on stack, i.e. from r11 */
                 var = find_local_var(ii->str_param1, blk);
-                if (var == NULL) /* not found? */
+                if (!var) /* not found? */
                     abort();
 
                 offset = -var->offset;

--- a/src/elf.c
+++ b/src/elf.c
@@ -262,7 +262,7 @@ void elf_generate(char *outfile)
     elf_generate_header();
     elf_generate_sections();
 
-    if (outfile == NULL)
+    if (!outfile)
         outfile = "a.out";
 
     fp = fopen(outfile, "wb");

--- a/src/globals.c
+++ b/src/globals.c
@@ -43,7 +43,7 @@ type_t *find_type(char *type_name)
 {
     int i;
     for (i = 0; i < types_idx; i++)
-        if (strcmp(TYPES[i].type_name, type_name) == 0)
+        if (!strcmp(TYPES[i].type_name, type_name))
             return &TYPES[i];
     return NULL;
 }
@@ -79,7 +79,7 @@ char *find_alias(char alias[])
 {
     int i;
     for (i = 0; i < aliases_idx; i++)
-        if (strcmp(alias, ALIASES[i].alias) == 0)
+        if (!strcmp(alias, ALIASES[i].alias))
             return ALIASES[i].value;
     return NULL;
 }
@@ -91,7 +91,7 @@ func_t *add_func(char *name)
 
     /* return existing if found */
     for (i = 0; i < funcs_idx; i++)
-        if (strcmp(FUNCS[i].return_def.var_name, name) == 0)
+        if (!strcmp(FUNCS[i].return_def.var_name, name))
             return &FUNCS[i];
 
     fn = &FUNCS[funcs_idx++];
@@ -122,7 +122,7 @@ constant_t *find_constant(char alias[])
 {
     int i;
     for (i = 0; i < constants_idx; i++)
-        if (strcmp(CONSTANTS[i].alias, alias) == 0)
+        if (!strcmp(CONSTANTS[i].alias, alias))
             return &CONSTANTS[i];
     return NULL;
 }
@@ -131,7 +131,7 @@ func_t *find_func(char func_name[])
 {
     int i;
     for (i = 0; i < funcs_idx; i++)
-        if (strcmp(FUNCS[i].return_def.var_name, func_name) == 0)
+        if (!strcmp(FUNCS[i].return_def.var_name, func_name))
             return &FUNCS[i];
     return NULL;
 }
@@ -140,7 +140,7 @@ var_t *find_member(char token[], type_t *type)
 {
     int i;
     for (i = 0; i < type->num_fields; i++)
-        if (strcmp(type->fields[i].var_name, token) == 0)
+        if (!strcmp(type->fields[i].var_name, token))
             return &type->fields[i];
     return NULL;
 }
@@ -152,13 +152,13 @@ var_t *find_local_var(char *token, block_t *block)
 
     for (; block; block = block->parent) {
         for (i = 0; i < block->next_local; i++)
-            if (strcmp(block->locals[i].var_name, token) == 0)
+            if (!strcmp(block->locals[i].var_name, token))
                 return &block->locals[i];
     }
 
     if (fn) {
         for (i = 0; i < fn->num_params; i++)
-            if (strcmp(fn->param_defs[i].var_name, token) == 0)
+            if (!strcmp(fn->param_defs[i].var_name, token))
                 return &fn->param_defs[i];
     }
     return NULL;
@@ -170,7 +170,7 @@ var_t *find_global_var(char *token)
     block_t *block = &BLOCKS[0];
 
     for (i = 0; i < block->next_local; i++)
-        if (strcmp(block->locals[i].var_name, token) == 0)
+        if (!strcmp(block->locals[i].var_name, token))
             return &block->locals[i];
     return NULL;
 }
@@ -178,7 +178,7 @@ var_t *find_global_var(char *token)
 var_t *find_var(char *token, block_t *parent)
 {
     var_t *var = find_local_var(token, parent);
-    if (var == NULL)
+    if (!var)
         var = find_global_var(token);
     return var;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -29,11 +29,11 @@ int main(int argc, char *argv[])
     int i;
 
     for (i = 1; i < argc; i++) {
-        if (strcmp(argv[i], "--dump-ir") == 0)
+        if (!strcmp(argv[i], "--dump-ir"))
             dump_ir = 1;
-        else if (strcmp(argv[i], "--no-libc") == 0)
+        else if (!strcmp(argv[i], "--no-libc"))
             libc = 0;
-        else if (strcmp(argv[i], "-o") == 0) {
+        else if (!strcmp(argv[i], "-o")) {
             if (i < argc + 1) {
                 out = argv[i + 1];
                 i++;
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
             in = argv[i];
     }
 
-    if (in == NULL) {
+    if (!in) {
         printf("Missing source file!\n");
         printf("Usage: shecc [-o output] [--dump-ir] [--no-libc] <input.c>\n");
         return -1;

--- a/tools/inliner.c
+++ b/tools/inliner.c
@@ -50,7 +50,7 @@ void load_from(char *file)
     char buffer[MAX_LINE_LEN];
     FILE *f = fopen(file, "rb");
     for (;;) {
-        if (fgets(buffer, MAX_LINE_LEN, f) == NULL) {
+        if (!fgets(buffer, MAX_LINE_LEN, f)) {
             fclose(f);
             return;
         }


### PR DESCRIPTION
This patch replaced all occurrences of "0 == strcmp(a, b)" with
"!strcmp(a, b)". Also, all expressions containing "!= NULL" were changed
into the simplified form.