### PR TITLE
Support ternary operator

### DIFF
--- a/src/defs.h
+++ b/src/defs.h
@@ -10,12 +10,12 @@
 #define MAX_LOCALS 48
 #define MAX_FIELDS 32
 #define MAX_FUNCS 1024
-#define MAX_BLOCKS 65536
+#define MAX_BLOCKS 262144
 #define MAX_TYPES 64
 #define MAX_IR_INSTR 65536
-#define MAX_SOURCE 131072
-#define MAX_CODE 131072
-#define MAX_DATA 131072
+#define MAX_SOURCE 262144
+#define MAX_CODE 262144
+#define MAX_DATA 262144
 #define MAX_SYMTAB 65536
 #define MAX_STRTAB 65536
 #define MAX_HEADER 1024
@@ -67,8 +67,9 @@ typedef enum {
     OP_add,
     OP_sub,
     OP_mul,
-    OP_div, /* signed division */
-    OP_mod, /* modulo */
+    OP_div,     /* signed division */
+    OP_mod,     /* modulo */
+    OP_ternary, /* ? : */
     OP_lshift,
     OP_rshift,
     OP_log_and,

--- a/tests/driver.sh
+++ b/tests/driver.sh
@@ -259,8 +259,8 @@ int main()
 EOF
 
 # conditional operator
-# expr 10 "1 ? 10 : 5"
-# expr 25 "0 ? 10 : 25"
+expr 10 "1 ? 10 : 5"
+expr 25 "0 ? 10 : 25"
 
 # compound assignemnt
 items 5 "int a; a = 2; a += 3; return a;"


### PR DESCRIPTION
This patch support ternary operator in:
1. global variable initialization
2. local variable initialization & assignment
3. expression of return
4. parameter list of function call

This patch also increases limitations in `defs.h` because size of shecc grows a lot!    (See #36 )