### PR TITLE
Simplify source by means of ternary operator

### DIFF
--- a/src/cfront.c
+++ b/src/cfront.c
@@ -2,33 +2,25 @@
 
 int is_whitespace(char c)
 {
-    if (c == ' ' || c == '\r' || c == '\n' || c == '\t')
-        return 1;
-    return 0;
+    return (c == ' ' || c == '\r' || c == '\n' || c == '\t');
 }
 
 /* is it alphabet, number or '_'? */
 int is_alnum(char c)
 {
-    if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
-        (c >= '0' && c <= '9') || (c == '_'))
-        return 1;
-    return 0;
+    return ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+            (c >= '0' && c <= '9') || (c == '_'));
 }
 
 int is_digit(char c)
 {
-    if (c >= '0' && c <= '9')
-        return 1;
-    return 0;
+    return (c >= '0' && c <= '9') ? 1 : 0;
 }
 
 int is_hex(char c)
 {
-    if ((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || c == 'x' ||
-        (c >= 'A' && c <= 'F'))
-        return 1;
-    return 0;
+    return ((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || c == 'x' ||
+            (c >= 'A' && c <= 'F'));
 }
 
 /* lexer tokens */
@@ -1254,10 +1246,7 @@ void read_lvalue(lvalue_t *lvalue,
                 ii->int_param1 = 1;
 
                 /* add 1 */
-                if (lex_accept(T_increment))
-                    ii = add_instr(OP_add);
-                else
-                    ii = add_instr(OP_sub);
+                ii = add_instr(lex_accept(T_increment) ? OP_add : OP_sub);
                 ii->param_no = param_no + 1;
                 ii->int_param1 = param_no + 2;
 

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -28,12 +28,9 @@ int size_block(block_t *blk)
     int size = 0, i, offset;
 
     /* our offset starts from parent's offset */
-    if (!blk->parent) {
-        if (blk->func)
-            offset = blk->func->params_size;
-        else
-            offset = 0;
-    } else
+    if (!blk->parent)
+        offset = blk->func ? blk->func->params_size : 0;
+    else
         offset = size_block(blk->parent);
 
     /* declared locals */
@@ -95,19 +92,13 @@ int get_code_length(ir_instr_t *ii)
         return 16 + (fn->num_params << 2);
     }
     case OP_call:
-        if (ii->param_no)
-            return 8;
-        return 4;
+        return ii->param_no ? 8 : 4;
     case OP_load_constant:
-        if (ii->int_param1 >= 0 && ii->int_param1 < 256)
-            return 4;
-        return 8;
+        return (ii->int_param1 >= 0 && ii->int_param1 < 256) ? 4 : 8;
     case OP_block_start:
     case OP_block_end: {
         block_t *blk = &BLOCKS[ii->int_param1];
-        if (blk->next_local > 0)
-            return 4;
-        return 0;
+        return (blk->next_local > 0) ? 4 : 0;
     }
     case OP_eq:
     case OP_neq:

--- a/src/elf.c
+++ b/src/elf.c
@@ -237,10 +237,7 @@ void elf_add_symbol(char *symbol, int len, int pc)
     elf_write_symbol_int(elf_strtab_index);
     elf_write_symbol_int(pc);
     elf_write_symbol_int(0);
-    if (pc == 0)
-        elf_write_symbol_int(0);
-    else
-        elf_write_symbol_int(1 << 16);
+    elf_write_symbol_int(pc == 0 ? 0 : 1 << 16);
 
     strncpy(elf_strtab + elf_strtab_index, symbol, len);
     elf_strtab_index += len;


### PR DESCRIPTION
The line of code reported by 'cloc src' was reduced from 3055 to 3032.