### PR TITLE
Fix missing terminating " character error in libc generated by inliner

### DIFF
--- a/tools/inliner.c
+++ b/tools/inliner.c
@@ -28,17 +28,27 @@ void write_str(char *str)
 
 void write_line(char *src)
 {
-    int i;
-
+    int i,j;
     write_str("  __c(\"");
+
     for (i = 0; src[i]; i++) {
         if (src[i] == '\"') {
             write_char('\\');
             write_char('\"');
         } else if (src[i] != '\n') {
             write_char(src[i]);
+        } else if (src[i] == '\n') {
+            write_char('\\');
+            write_char('\n');
         }
     }
+
+    for (j = 0; SOURCE[j]; j++) {
+        if (SOURCE[j] == '\r') {
+            SOURCE[j] = ' ';
+        }
+    }
+    /* remove \r character */
 
     write_char('\\');
     write_char('n');


### PR DESCRIPTION
When I was trying to build shecc, my compiler just threw me an `missing terminating " character` in the libc build stage, so I update the inliner to write a `\` character at the end of every line. Now it just throws me an `Segmentation fault (core dumped)` runtime error in the compiler executable (I'll try to fix it too).