### PR TITLE
Implement RISC-V backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ a.out
 *.elf
 *.log
 *.lst
+config
+src/codegen.c

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,8 @@ script:
   - make config ARCH=arm
   - make VERBOSE=1      
   - make check
+  - make clean
+  - make config ARCH=riscv
+  - make VERBOSE=1
+  - make check
   - sh .ci/check-format.sh

--- a/Makefile
+++ b/Makefile
@@ -26,12 +26,15 @@ all: bootstrap
 
 config:
 ifeq (riscv,$(ARCH))
-	@echo $(RISCV_EXEC) > $(OUT)/target
+	@$(VECHO) "$(RISCV_EXEC)" > $(OUT)/target
+	@$(VECHO) "#define TARGET_RISCV 1" > $@
+	@ln -s $(PWD)/$(SRCDIR)/riscv-codegen.c $(SRCDIR)/codegen.c
 else
-	@echo $(ARM_EXEC) > $(OUT)/target
+	@$(VECHO) "$(ARM_EXEC)" > $(OUT)/target
+	@$(VECHO) "#define TARGET_ARM 1" > $@
+	@ln -s $(PWD)/$(SRCDIR)/arm-codegen.c $(SRCDIR)/codegen.c
 endif
-	@echo -n Target machine code switch to
-	@echo `cat $(OUT)/target` | sed 's/.*qemu-\([^ ]*\).*/ \1/'
+	@$(VECHO) "Target machine code switch to %s\n" "$$(cat out/target | sed 's/.*qemu-\([^ ]*\).*/\1/')"
 
 $(OUT)/tests/%.elf: tests/%.c $(OUT)/$(STAGE0)
 	$(VECHO) "  SHECC\t$@\n"
@@ -80,6 +83,6 @@ clean:
 	-$(RM) $(OBJS) $(deps)
 	-$(RM) $(TESTBINS) $(OUT)/tests/*.log $(OUT)/tests/*.lst
 	-$(RM) $(OUT)/shecc*.log
-	-$(RM) $(OUT)/inliner $(OUT)/libc.inc $(OUT)/target
+	-$(RM) $(OUT)/inliner $(OUT)/libc.inc $(OUT)/target config $(SRCDIR)/codegen.c
 
 -include $(deps)

--- a/lib/c.c
+++ b/lib/c.c
@@ -11,6 +11,16 @@
 #define __syscall_brk 45
 #endif
 
+#ifdef __riscv
+#define __syscall_exit 93
+#define __syscall_read 63
+#define __syscall_write 64
+#define __syscall_close 57
+#define __syscall_open 1024
+#define __syscall_openat 56
+#define __syscall_brk 214
+#endif
+
 typedef int FILE;
 
 void abort();
@@ -316,9 +326,21 @@ void abort()
 FILE *fopen(char *filename, char *mode)
 {
     if (!strcmp(mode, "wb"))
+#ifdef __arm__
         return __syscall(__syscall_open, filename, 65, 0x1fd);
+#endif
+/* FIXME: mode not work currently in RISC-V */
+#ifdef __riscv
+    return __syscall(__syscall_openat, -100, filename, 65, 0x1fd);
+#endif
     if (!strcmp(mode, "rb"))
+#ifdef __arm__
         return __syscall(__syscall_open, filename, 0, 0);
+#endif
+#ifdef __riscv
+    return __syscall(__syscall_openat, -100, filename, 0, 0);
+#endif
+
     abort();
 }
 

--- a/src/cfront.c
+++ b/src/cfront.c
@@ -2145,8 +2145,15 @@ void parse_internal()
     add_block(NULL, NULL);    /* global block */
     elf_add_symbol("", 0, 0); /* undef symbol */
 
-    /* architecture defines */
+/* architecture defines */
+/* FIXME: use #ifdef ... #else ... #endif */
+#ifdef TARGET_ARM
     add_alias("__arm__", "1"); /* defined by GNU C and RealView */
+#endif
+#ifdef TARGET_RISCV
+    /* Older versions of the GCC toolchain defined __riscv__ */
+    add_alias("__riscv", "1");
+#endif
 
     /* binary entry point: read params, call main, exit */
     ii = add_instr(OP_label);

--- a/src/elf.c
+++ b/src/elf.c
@@ -82,7 +82,13 @@ void elf_generate_header()
     elf_write_header_int(0);          /* EI_PAD: unused */
     elf_write_header_byte(2);         /* ET_EXEC */
     elf_write_header_byte(0);
+/* FIXME: use #ifdef ... #else ... #endif */
+#ifdef TARGET_ARM
     elf_write_header_byte(0x28); /* ARM (up to ARMv7/Aarch32) */
+#endif
+#ifdef TARGET_RISCV
+    elf_write_header_byte(0xf3); /* RISC-V */
+#endif
     elf_write_header_byte(0);
     elf_write_header_int(1);                          /* ELF version */
     elf_write_header_int(ELF_START + elf_header_len); /* entry point */
@@ -90,9 +96,15 @@ void elf_generate_header()
     elf_write_header_int(elf_header_len + elf_code_idx + elf_data_idx + 39 +
                          elf_symtab_index +
                          elf_strtab_index); /* section header offset */
-    /* flags */
+/* flags */
+/* FIXME: use #ifdef ... #else ... #endif */
+#ifdef TARGET_ARM
     elf_write_header_int(0x5000200); /* ARM */
-    elf_write_header_byte(0x34);     /* header size */
+#endif
+#ifdef TARGET_RISCV
+    elf_write_header_int(0);
+#endif
+    elf_write_header_byte(0x34); /* header size */
     elf_write_header_byte(0);
     elf_write_header_byte(0x20); /* program header size */
     elf_write_header_byte(0);

--- a/src/main.c
+++ b/src/main.c
@@ -4,6 +4,9 @@
 #include <stdlib.h>
 #include <string.h>
 
+/* Define target machine */
+#include "../config"
+
 /* The inclusion must follow the fixed order, otherwise it fails to build. */
 #include "defs.h"
 
@@ -17,7 +20,7 @@
 #include "cfront.c"
 
 /* Machine code generation. support ARMv7-A and RISC-V32I */
-#include "arm-codegen.c"
+#include "codegen.c"
 
 /* inlined libc */
 #include "../out/libc.inc"

--- a/src/riscv-codegen.c
+++ b/src/riscv-codegen.c
@@ -1,0 +1,596 @@
+/* Translate IR to target machine code */
+
+#include "riscv.c"
+
+/* Compute stack space needed for function's parameters */
+void size_func(func_t *fn)
+{
+    int s = 0, i;
+
+    /* parameters are turned into local variables */
+    for (i = 0; i < fn->num_params; i++) {
+        s += size_var(&fn->param_defs[i]);
+        fn->param_defs[i].offset = s; /* stack offset */
+    }
+
+    /* align to 16 bytes */
+    if ((s & 15) > 0)
+        s = (s - (s & 15)) + 16;
+    if (s > 2047)
+        error("Local stack size exceeded");
+
+    fn->params_size = s;
+}
+
+/* Return stack size required after block local variables */
+int size_block(block_t *blk)
+{
+    int size = 0, i, offset;
+
+    /* our offset starts from parent's offset */
+    if (!blk->parent)
+        offset = blk->func ? blk->func->params_size : 0;
+    else
+        offset = size_block(blk->parent);
+
+    /* declared locals */
+    for (i = 0; i < blk->next_local; i++) {
+        int vs = size_var(&blk->locals[i]);
+        /* look up value off stack */
+        blk->locals[i].offset = size + offset + vs;
+        size += vs;
+    }
+
+    /* align to 16 bytes */
+    if ((size & 15) > 0)
+        size = (size - (size & 15)) + 16;
+    if (size > 2047)
+        error("Local stack size exceeded");
+
+    /* save in block for stack allocation */
+    blk->locals_size = size;
+    return size + offset;
+}
+
+/* Compute stack necessary sizes for all functions */
+void size_funcs(int data_start)
+{
+    block_t *blk;
+    int i;
+
+    /* size functions */
+    for (i = 0; i < funcs_idx; i++)
+        size_func(&FUNCS[i]);
+
+    /* size blocks excl. global block */
+    for (i = 1; i < blocks_idx; i++)
+        size_block(&BLOCKS[i]);
+
+    /* allocate data for globals, in block 0 */
+    blk = &BLOCKS[0];
+    for (i = 0; i < blk->next_local; i++) {
+        blk->locals[i].offset = elf_data_idx; /* set offset in data section */
+        elf_add_symbol(blk->locals[i].var_name, strlen(blk->locals[i].var_name),
+                       data_start + elf_data_idx);
+        /* TODO: add .bss section */
+        if (!strcmp(blk->locals[i].type_name, "int") &&
+            blk->locals[i].init_val != 0)
+            elf_write_data_int(blk->locals[i].init_val);
+        else
+            elf_data_idx += size_var(&blk->locals[i]);
+    }
+}
+
+/* Return expected binary length of an IR instruction in bytes */
+int get_code_length(ir_instr_t *ii)
+{
+    opcode_t op = ii->op;
+
+    switch (op) {
+    case OP_func_extry: {
+        func_t *fn = find_func(ii->str_param1);
+        return 16 + (fn->num_params << 2);
+    }
+    case OP_call:
+        return ii->param_no ? 8 : 4;
+    case OP_load_constant:
+        return (ii->int_param1 > -2048 && ii->int_param1 < 2047) ? 4 : 8;
+    case OP_block_start:
+    case OP_block_end: {
+        block_t *blk = &BLOCKS[ii->int_param1];
+        return (blk->next_local > 0) ? 4 : 0;
+    }
+    case OP_syscall:
+        return 20;
+    case OP_eq:
+    case OP_neq:
+    case OP_lt:
+    case OP_leq:
+    case OP_gt:
+    case OP_geq:
+    case OP_func_exit:
+        return 16;
+    case OP_exit:
+        return 12;
+    case OP_load_data_address:
+    case OP_jz:
+    case OP_jnz:
+    case OP_push:
+    case OP_pop:
+    case OP_address_of:
+    case OP_start:
+        return 8;
+    case OP_jump:
+    case OP_return:
+    case OP_add:
+    case OP_sub:
+    case OP_mul:
+    case OP_div:
+    case OP_mod:
+    case OP_read:
+    case OP_write:
+    case OP_log_or:
+    case OP_log_and:
+    case OP_log_not:
+    case OP_bit_or:
+    case OP_bit_and:
+    case OP_bit_xor:
+    case OP_bit_not:
+    case OP_negate:
+    case OP_lshift:
+    case OP_rshift:
+        return 4;
+    case OP_label:
+        return 0;
+    default:
+        error("Unsupported IR opcode");
+    }
+    return 0;
+}
+
+void emit(int code)
+{
+    elf_write_code_int(code);
+}
+
+/* Compute total binary code length based on IR opcode */
+int total_code_length()
+{
+    int code_len = 0, i;
+    for (i = 0; i < ir_idx; i++) {
+        IR[i].code_offset = code_len;
+        IR[i].op_len = get_code_length(&IR[i]);
+        code_len += IR[i].op_len;
+    }
+    return code_len;
+}
+
+void code_generate()
+{
+    int stack_size = 0, i;
+    block_t *blk = NULL;
+    int _c_block_level = 0;
+
+    int code_start = elf_code_start; /* ELF headers size */
+    int data_start = total_code_length();
+    size_funcs(code_start + data_start);
+    for (i = 0; i < ir_idx; i++) {
+        var_t *var;
+        func_t *fn;
+
+        ir_instr_t *ii = &IR[i];
+        opcode_t op = ii->op;
+        int pc = elf_code_idx;
+        int ofs, val;
+        int dest_reg = ii->param_no + 10; /* RISC-V specific */
+        int OP_reg = ii->int_param1 + 10; /* RISC-V specific */
+
+        if (dump_ir == 1) {
+            int j;
+            printf("%#010x     ", code_start + pc);
+            /* Use 4 space indentation */
+            for (j = 0; j < _c_block_level; j++)
+                printf("    ");
+        }
+
+        switch (op) {
+        case OP_load_data_address:
+            /* lookup address of a constant in data section */
+            ofs = data_start + ii->int_param1;
+            ofs -= pc;
+            emit(__auipc(dest_reg, rv_hi(ofs)));
+            emit(__addi(dest_reg, dest_reg, rv_lo(ofs)));
+            if (dump_ir == 1)
+                printf("    x%d := &data[%d]", dest_reg, ii->int_param1);
+            break;
+        case OP_load_constant:
+            /* load numeric constant */
+            val = ii->int_param1;
+            if (val > -2048 && val < 2047) {
+                emit(__addi(dest_reg, __zero, rv_lo(val)));
+            } else {
+                emit(__lui(dest_reg, rv_hi(val)));
+                emit(__addi(dest_reg, dest_reg, rv_lo(val)));
+            }
+            if (dump_ir == 1)
+                printf("    x%d := %d", dest_reg, ii->int_param1);
+            break;
+        case OP_address_of:
+            /* lookup address of a variable */
+            var = find_global_var(ii->str_param1);
+            if (var) {
+                int ofs = data_start + var->offset, offset;
+                /* need to find the variable offset in data section, from PC */
+                ofs -= pc;
+
+                emit(__auipc(dest_reg, rv_hi(ofs)));
+                offset = rv_lo(ofs);
+                emit(__addi(dest_reg, dest_reg, offset));
+            } else {
+                int offset;
+                /* need to find the variable offset on stack, i.e. from s0 */
+                var = find_local_var(ii->str_param1, blk);
+                if (!var)
+                    abort(); /* not found? */
+
+                offset = -var->offset;
+                emit(__addi(dest_reg, __s0, 0));
+                emit(__addi(dest_reg, dest_reg, offset));
+            }
+            if (dump_ir == 1)
+                printf("    x%d = &%s", dest_reg, ii->str_param1);
+            break;
+        case OP_read:
+            /* read (dereference) memory address */
+            switch (ii->int_param2) {
+            case 4:
+                emit(__lw(dest_reg, OP_reg, 0));
+                break;
+            case 1:
+                emit(__lb(dest_reg, OP_reg, 0));
+                break;
+            default:
+                error("Unsupported word size");
+            }
+            if (dump_ir == 1)
+                printf("    x%d = *x%d (%d)", dest_reg, OP_reg, ii->int_param2);
+            break;
+        case OP_write:
+            /* write at memory address */
+            switch (ii->int_param2) {
+            case 4:
+                emit(__sw(dest_reg, OP_reg, 0));
+                break;
+            case 1:
+                emit(__sb(dest_reg, OP_reg, 0));
+                break;
+            default:
+                error("Unsupported word size");
+            }
+            if (dump_ir == 1)
+                printf("    *x%d = x%d (%d)", OP_reg, dest_reg, ii->int_param2);
+            break;
+        case OP_jump: {
+            /* unconditional jump to an IL-index */
+            int jump_instr_index = ii->int_param1;
+            ir_instr_t *jump_instr = &IR[jump_instr_index];
+            int jump_location = jump_instr->code_offset;
+            ofs = jump_location - pc;
+
+            emit(__jal(__zero, ofs));
+            if (dump_ir == 1)
+                printf("    goto %d", ii->int_param1);
+        } break;
+        case OP_return: {
+            /* jump to function exit */
+            func_t *fd = find_func(ii->str_param1);
+            int jump_instr_index = fd->exit_point;
+            ir_instr_t *jump_instr = &IR[jump_instr_index];
+            int jump_location = jump_instr->code_offset;
+            ofs = jump_location - pc;
+
+            emit(__jal(__zero, ofs));
+            if (dump_ir == 1)
+                printf("    return (from %s)", ii->str_param1);
+        } break;
+        case OP_call: {
+            /* function call */
+            int jump_instr_index;
+            ir_instr_t *jump_instr;
+            int jump_location;
+
+            /* need to find offset */
+            fn = find_func(ii->str_param1);
+            jump_instr_index = fn->entry_point;
+            jump_instr = &IR[jump_instr_index];
+            jump_location = jump_instr->code_offset;
+            ofs = jump_location - pc;
+
+            emit(__jal(__ra, ofs));
+            if (dest_reg != __a0)
+                emit(__add(dest_reg, __zero, OP_reg));
+            if (dump_ir == 1)
+                printf("    x%d := %s() @ %d", dest_reg, ii->str_param1,
+                       fn->entry_point);
+        } break;
+        case OP_push:
+            /* 16 aligned although we only need 4 */
+            emit(__addi(__sp, __sp, -16));
+            emit(__sw(dest_reg, __sp, 0));
+            if (dump_ir == 1)
+                printf("    push x%d", dest_reg);
+            break;
+        case OP_pop:
+            emit(__lw(dest_reg, __sp, 0));
+            /* 16 aligned although we only need 4 */
+            emit(__addi(__sp, __sp, 16));
+            if (dump_ir == 1)
+                printf("    pop x%d", dest_reg);
+            break;
+        case OP_func_exit:
+            /* restore previous frame */
+            emit(__addi(__sp, __s0, 16));
+            emit(__lw(__ra, __sp, -8));
+            emit(__lw(__s0, __sp, -4));
+            emit(__jalr(__zero, __ra, 0));
+            fn = NULL;
+            if (dump_ir == 1)
+                printf("    exit %s", ii->str_param1);
+            break;
+        case OP_add:
+            emit(__add(dest_reg, dest_reg, OP_reg));
+            if (dump_ir == 1)
+                printf("    x%d += x%d", dest_reg, OP_reg);
+            break;
+        case OP_sub:
+            emit(__sub(dest_reg, dest_reg, OP_reg));
+            if (dump_ir == 1)
+                printf("    x%d -= x%d", dest_reg, OP_reg);
+            break;
+        case OP_mul:
+            emit(__mul(dest_reg, dest_reg, OP_reg));
+            if (dump_ir == 1)
+                printf("    x%d *= x%d", dest_reg, OP_reg);
+            break;
+        case OP_div:
+            emit(__div(dest_reg, dest_reg, OP_reg));
+            if (dump_ir == 1)
+                printf("    x%d /= x%d", dest_reg, OP_reg);
+            break;
+        case OP_mod:
+            emit(__mod(dest_reg, dest_reg, OP_reg));
+            if (dump_ir == 1)
+                printf("    x%d = x%d mod x%d", dest_reg, dest_reg, OP_reg);
+            break;
+        case OP_negate:
+            emit(__sub(dest_reg, __zero, dest_reg));
+            if (dump_ir == 1)
+                printf("    -x%d", dest_reg);
+            break;
+        case OP_label:
+            if (ii->str_param1)
+                /* TODO: lazy eval */
+                if (strlen(ii->str_param1) > 0)
+                    elf_add_symbol(ii->str_param1, strlen(ii->str_param1),
+                                   code_start + pc);
+            if (dump_ir == 1)
+                printf("%4d:", i);
+            break;
+        case OP_eq:
+        case OP_neq:
+        case OP_lt:
+        case OP_leq:
+        case OP_gt:
+        case OP_geq:
+            /* we want 1/nonzero if equ, 0 otherwise */
+            switch (op) {
+            case OP_eq:
+                emit(__beq(dest_reg, OP_reg, 12));
+                break;
+            case OP_neq:
+                emit(__bne(dest_reg, OP_reg, 12));
+                break;
+            case OP_lt:
+                emit(__blt(dest_reg, OP_reg, 12));
+                break;
+            case OP_geq:
+                emit(__bge(dest_reg, OP_reg, 12));
+                break;
+            case OP_gt:
+                emit(__blt(OP_reg, dest_reg, 12));
+                break;
+            case OP_leq:
+                emit(__bge(OP_reg, dest_reg, 12));
+                break;
+            default:
+                error("Unsupported conditional IR op");
+                break;
+            }
+            emit(__addi(dest_reg, __zero, 0));
+            emit(__jal(__zero, 8));
+            emit(__addi(dest_reg, __zero, 1));
+
+            if (dump_ir == 1) {
+                switch (op) {
+                case OP_eq:
+                    printf("    x%d == x%d ?", dest_reg, OP_reg);
+                    break;
+                case OP_neq:
+                    printf("    x%d != x%d ?", dest_reg, OP_reg);
+                    break;
+                case OP_lt:
+                    printf("    x%d < x%d ?", dest_reg, OP_reg);
+                    break;
+                case OP_geq:
+                    printf("    x%d >= x%d ?", dest_reg, OP_reg);
+                    break;
+                case OP_gt:
+                    printf("    x%d > x%d ?", dest_reg, OP_reg);
+                    break;
+                case OP_leq:
+                    printf("    x%d <= x%d ?", dest_reg, OP_reg);
+                    break;
+                default:
+                    break;
+                }
+            }
+            break;
+        case OP_log_and:
+            /* we assume both have to be 1, they can not be just nonzero */
+            emit(__and(dest_reg, dest_reg, OP_reg));
+            if (dump_ir == 1)
+                printf("    x%d &&= x%d", dest_reg, OP_reg);
+            break;
+        case OP_log_or:
+            emit(__or(dest_reg, dest_reg, OP_reg));
+            if (dump_ir == 1)
+                printf("    x%d ||= x%d", dest_reg, OP_reg);
+            break;
+        case OP_bit_and:
+            emit(__and(dest_reg, dest_reg, OP_reg));
+            if (dump_ir == 1)
+                printf("    x%d &= x%d", dest_reg, OP_reg);
+            break;
+        case OP_bit_or:
+            emit(__or(dest_reg, dest_reg, OP_reg));
+            if (dump_ir == 1)
+                printf("    x%d |= x%d", dest_reg, OP_reg);
+            break;
+        case OP_bit_xor:
+            emit(__xor(dest_reg, dest_reg, OP_reg));
+            if (dump_ir == 1)
+                printf("    x%d ^= x%d", dest_reg, OP_reg);
+            break;
+        case OP_bit_not:
+            emit(__xori(dest_reg, dest_reg, -1));
+            if (dump_ir == 1)
+                printf("    x%d ~= x%d", dest_reg, OP_reg);
+            break;
+        case OP_lshift:
+            emit(__sll(dest_reg, dest_reg, OP_reg));
+            if (dump_ir == 1)
+                printf("    x%d <<= x%d", dest_reg, OP_reg);
+            break;
+        case OP_rshift:
+            emit(__srl(dest_reg, dest_reg, OP_reg));
+            if (dump_ir == 1)
+                printf("    x%d >>= x%d", dest_reg, OP_reg);
+            break;
+        case OP_log_not:
+            /* 1 if zero, 0 if nonzero */
+            /* only works for small range integers */
+            emit(__sltiu(dest_reg, dest_reg, 1));
+            if (dump_ir == 1)
+                printf("    !x%d", dest_reg);
+            break;
+        case OP_jz:
+        case OP_jnz: {
+            /* conditional jumps to IR-index */
+            int jump_instr_index = ii->int_param1;
+            ir_instr_t *jump_instr = &IR[jump_instr_index];
+            int jump_location = jump_instr->code_offset;
+            int ofs = jump_location - pc - 4;
+
+            if (ofs >= -4096 && ofs <= 4095) {
+                if (op == OP_jz) { /* near jump (branch) */
+                    emit(__nop());
+                    emit(__beq(dest_reg, __zero, ofs));
+                    if (dump_ir == 1)
+                        printf("    if false then goto %d", ii->int_param1);
+                } else if (op == OP_jnz) {
+                    emit(__nop());
+                    emit(__bne(dest_reg, __zero, ofs));
+                    if (dump_ir == 1)
+                        printf("    if true then goto %d", ii->int_param1);
+                }
+            } else { /* far jump */
+                if (op == OP_jz) {
+                    /* skip next instruction */
+                    emit(__bne(dest_reg, __zero, 8));
+                    emit(__jal(__zero, ofs));
+                    if (dump_ir == 1)
+                        printf("    if false then goto %d", ii->int_param1);
+                } else if (op == OP_jnz) {
+                    emit(__beq(dest_reg, __zero, 8));
+                    emit(__jal(__zero, ofs));
+                    if (dump_ir == 1)
+                        printf("    if true then goto %d", ii->int_param1);
+                }
+            }
+        } break;
+        case OP_block_start:
+            blk = &BLOCKS[ii->int_param1];
+            if (blk->next_local > 0) {
+                /* reserve stack space for locals */
+                emit(__addi(__sp, __sp, -blk->locals_size));
+                stack_size += blk->locals_size;
+            }
+            if (dump_ir == 1)
+                printf("    {");
+            _c_block_level++;
+            break;
+        case OP_block_end:
+            blk = &BLOCKS[ii->int_param1]; /* should not be necessarry */
+            if (blk->next_local > 0) {
+                /* remove stack space for locals */
+                emit(__addi(__sp, __sp, blk->locals_size));
+                stack_size -= blk->locals_size;
+            }
+            /* blk is current block */
+            blk = blk->parent;
+            if (dump_ir == 1)
+                printf("}");
+            _c_block_level--;
+            break;
+        case OP_func_extry: {
+            int pn, ps;
+            fn = find_func(ii->str_param1);
+            ps = fn->params_size;
+
+            /* add to symbol table */
+            elf_add_symbol(ii->str_param1, strlen(ii->str_param1),
+                           code_start + pc);
+
+            /* create stack space for params and parent frame */
+            emit(__addi(__sp, __sp, -16 - ps));
+            emit(__sw(__s0, __sp, 12 + ps));
+            emit(__sw(__ra, __sp, 8 + ps));
+            emit(__addi(__s0, __sp, ps));
+            stack_size = ps;
+
+            /* push parameters on stack */
+            for (pn = 0; pn < fn->num_params; pn++) {
+                emit(__sw(__a0 + pn, __s0, -fn->param_defs[pn].offset));
+            }
+            if (dump_ir == 1)
+                printf("%s:", ii->str_param1);
+        } break;
+        case OP_start:
+            emit(__lw(__a0, __sp, 0));   /* argc */
+            emit(__addi(__a1, __sp, 4)); /* argv */
+            if (dump_ir == 1)
+                printf("    start");
+            break;
+        case OP_syscall:
+            emit(__addi(__a7, __a0, 0));
+            emit(__addi(__a0, __a1, 0));
+            emit(__addi(__a1, __a2, 0));
+            emit(__addi(__a2, __a3, 0));
+            emit(__ecall());
+            if (dump_ir == 1)
+                printf("    syscall");
+            break;
+        case OP_exit:
+            emit(__add(__a0, __zero, OP_reg));
+            emit(__addi(__a7, __zero, 93));
+            emit(__ecall());
+            if (dump_ir == 1)
+                printf("    exit");
+            break;
+        default:
+            error("Unsupported IR op");
+        }
+        if (dump_ir == 1)
+            printf("\n");
+    }
+}

--- a/src/riscv.c
+++ b/src/riscv.c
@@ -1,0 +1,398 @@
+/* RISC-V instruction encoding */
+
+/* opcodes */
+typedef enum {
+    /* R type */
+    rv_add = 51 /* 0b110011 + (0 << 12) */,
+    rv_sub = 1073741875 /* 0b110011 + (0 << 12) + (0x20 << 25) */,
+    rv_xor = 16435 /* 0b110011 + (4 << 12) */,
+    rv_or = 24627 /* 0b110011 + (6 << 12) */,
+    rv_and = 28723 /* 0b110011 + (7 << 12) */,
+    rv_sll = 4147 /* 0b110011 + (1 << 12) */,
+    rv_srl = 20531 /* 0b110011 + (5 << 12) */,
+    rv_sra = 1073762355 /* 0b110011 + (5 << 12) + (0x20 << 25) */,
+    rv_slt = 8243 /* 0b110011 + (2 << 12) */,
+    rv_sltu = 12339 /* 0b110011 + (3 << 12) */,
+    /* I type */
+    rv_addi = 19 /* 0b0010011 */,
+    rv_xori = 16403 /* 0b0010011 + (4 << 12) */,
+    rv_ori = 24595 /* 0b0010011 + (6 << 12) */,
+    rv_andi = 28691 /* 0b0010011 + (7 << 12) */,
+    rv_slli = 4115 /* 0b0010011 + (1 << 12) */,
+    rv_srli = 20499 /* 0b0010011 + (5 << 12) */,
+    rv_srai = 1073762323 /* 0b0010011 + (5 << 12) + (0x20 << 25) */,
+    rv_slti = 8211 /* 0b0010011 + (2 << 12) */,
+    rv_sltiu = 12307 /* 0b0010011 + (3 << 12) */,
+    /* load/store */
+    rv_lb = 3 /* 0b11 */,
+    rv_lh = 4099 /* 0b11 + (1 << 12) */,
+    rv_lw = 8195 /* 0b11 + (2 << 12) */,
+    rv_lbu = 16387 /* 0b11 + (4 << 12) */,
+    rv_lhu = 20483 /* 0b11 + (5 << 12) */,
+    rv_sb = 35 /* 0b0100011 */,
+    rv_sh = 4131 /* 0b0100011 + (1 << 12) */,
+    rv_sw = 8227 /* 0b0100011 + (2 << 12) */,
+    /* branch */
+    rv_beq = 99 /* 0b1100011 */,
+    rv_bne = 4195 /* 0b1100011 + (1 << 12) */,
+    rv_blt = 16483 /* 0b1100011 + (4 << 12) */,
+    rv_bge = 20579 /* 0b1100011 + (5 << 12) */,
+    rv_bltu = 24675 /* 0b1100011 + (6 << 12) */,
+    rv_bgeu = 28771 /* 0b1100011 + (7 << 12) */,
+    /* jumps */
+    rv_jal = 111 /* 0b1101111 */,
+    rv_jalr = 103 /* 0b1100111 */,
+    /* misc */
+    rv_lui = 55 /* 0b0110111 */,
+    rv_auipc = 23 /* 0b0010111 */,
+    rv_ecall = 115 /* 0b1110011 */,
+    rv_ebreak = 1048691 /* 0b1110011 + (1 << 20) */,
+    /* m */
+    rv_mul = 33554483 /* 0b0110011 + (1 << 25) */,
+    rv_div = 33570867 /* 0b0110011 + (1 << 25) + (4 << 12) */,
+    rv_mod = 33579059 /* 0b0110011 + (1 << 25) + (6 << 12) */
+} rv_op;
+
+/* registers */
+typedef enum {
+    __zero = 0,
+    __ra = 1,
+    __sp = 2,
+    __gp = 3,
+    __tp = 4,
+    __t0 = 5,
+    __t1 = 6,
+    __t2 = 7,
+    __s0 = 8,
+    __s1 = 9,
+    __a0 = 10,
+    __a1 = 11,
+    __a2 = 12,
+    __a3 = 13,
+    __a4 = 14,
+    __a5 = 15,
+    __a6 = 16,
+    __a7 = 17,
+    __s2 = 18,
+    __s3 = 19,
+    __s4 = 20,
+    __s5 = 21,
+    __s6 = 22,
+    __s7 = 23,
+    __s8 = 24,
+    __s9 = 25,
+    __s10 = 26,
+    __s11 = 27,
+    __t3 = 28,
+    __t4 = 29,
+    __t5 = 30,
+    __t6 = 31
+} rv_reg;
+
+int rv_extract_bits(int imm, int i_start, int i_end, int d_start, int d_end)
+{
+    int v;
+
+    if (d_end - d_start != i_end - i_start || i_start > i_end ||
+        d_start > d_end)
+        error("Invalid bit copy");
+
+    v = imm >> i_start;
+    v = v & ((2 << (i_end - i_start)) - 1);
+    v = v << d_start;
+    return v;
+}
+
+int rv_hi(int val)
+{
+    if ((val & (1 << 11)) != 0)
+        return val + 4096;
+    return val;
+}
+
+int rv_lo(int val)
+{
+    if ((val & (1 << 11)) != 0)
+        return (val & 0xFFF) - 4096;
+    return val & 0xFFF;
+}
+
+int rv_encode_R(rv_op op, rv_reg rd, rv_reg rs1, rv_reg rs2)
+{
+    return op + (rd << 7) + (rs1 << 15) + (rs2 << 20);
+}
+
+int rv_encode_I(rv_op op, rv_reg rd, rv_reg rs1, int imm)
+{
+    if (imm > 2047 || imm < -2048)
+        error("Offset too large");
+
+    if (imm < 0) {
+        imm += 4096;
+        imm &= (1 << 13) - 1;
+    }
+    return op + (rd << 7) + (rs1 << 15) + (imm << 20);
+}
+
+int rv_encode_S(rv_op op, rv_reg rs1, rv_reg rs2, int imm)
+{
+    if (imm > 2047 || imm < -2048)
+        error("Offset too large");
+
+    if (imm < 0) {
+        imm += 4096;
+        imm &= (1 << 13) - 1;
+    }
+    return op + (rs1 << 15) + (rs2 << 20) + rv_extract_bits(imm, 0, 4, 7, 11) +
+           rv_extract_bits(imm, 5, 11, 25, 31);
+}
+
+int rv_encode_B(rv_op op, rv_reg rs1, rv_reg rs2, int imm)
+{
+    int sign = 0;
+
+    /* 13 signed bits, with bit zero ignored */
+    if (imm > 4095 || imm < -4096)
+        error("Offset too large");
+
+    if (imm < 0)
+        sign = 1;
+
+    return op + (rs1 << 15) + (rs2 << 20) + rv_extract_bits(imm, 11, 11, 7, 7) +
+           rv_extract_bits(imm, 1, 4, 8, 11) +
+           rv_extract_bits(imm, 5, 10, 25, 30) + (sign << 31);
+}
+
+int rv_encode_J(rv_op op, rv_reg rd, int imm)
+{
+    int sign = 0;
+
+    if (imm < 0) {
+        sign = 1;
+        imm = -imm;
+        imm = (1 << 21) - imm;
+    }
+    return op + (rd << 7) + rv_extract_bits(imm, 1, 10, 21, 30) +
+           rv_extract_bits(imm, 11, 11, 20, 20) +
+           rv_extract_bits(imm, 12, 19, 12, 19) + (sign << 31);
+}
+
+int rv_encode_U(rv_op op, rv_reg rd, int imm)
+{
+    return op + (rd << 7) + rv_extract_bits(imm, 12, 31, 12, 31);
+}
+
+int __add(rv_reg rd, rv_reg rs1, rv_reg rs2)
+{
+    return rv_encode_R(rv_add, rd, rs1, rs2);
+}
+
+int __sub(rv_reg rd, rv_reg rs1, rv_reg rs2)
+{
+    return rv_encode_R(rv_sub, rd, rs1, rs2);
+}
+
+int __xor(rv_reg rd, rv_reg rs1, rv_reg rs2)
+{
+    return rv_encode_R(rv_xor, rd, rs1, rs2);
+}
+
+int __or(rv_reg rd, rv_reg rs1, rv_reg rs2)
+{
+    return rv_encode_R(rv_or, rd, rs1, rs2);
+}
+
+int __and(rv_reg rd, rv_reg rs1, rv_reg rs2)
+{
+    return rv_encode_R(rv_and, rd, rs1, rs2);
+}
+
+int __sll(rv_reg rd, rv_reg rs1, rv_reg rs2)
+{
+    return rv_encode_R(rv_sll, rd, rs1, rs2);
+}
+
+int __srl(rv_reg rd, rv_reg rs1, rv_reg rs2)
+{
+    return rv_encode_R(rv_srl, rd, rs1, rs2);
+}
+
+int __sra(rv_reg rd, rv_reg rs1, rv_reg rs2)
+{
+    return rv_encode_R(rv_sra, rd, rs1, rs2);
+}
+
+int __slt(rv_reg rd, rv_reg rs1, rv_reg rs2)
+{
+    return rv_encode_R(rv_slt, rd, rs1, rs2);
+}
+
+int __sltu(rv_reg rd, rv_reg rs1, rv_reg rs2)
+{
+    return rv_encode_R(rv_sltu, rd, rs1, rs2);
+}
+
+int __addi(rv_reg rd, rv_reg rs1, int imm)
+{
+    return rv_encode_I(rv_addi, rd, rs1, imm);
+}
+
+int __xori(rv_reg rd, rv_reg rs1, int imm)
+{
+    return rv_encode_I(rv_xori, rd, rs1, imm);
+}
+
+int __ori(rv_reg rd, rv_reg rs1, int imm)
+{
+    return rv_encode_I(rv_ori, rd, rs1, imm);
+}
+
+int __andi(rv_reg rd, rv_reg rs1, int imm)
+{
+    return rv_encode_I(rv_andi, rd, rs1, imm);
+}
+
+int __slli(rv_reg rd, rv_reg rs1, int imm)
+{
+    return rv_encode_I(rv_slli, rd, rs1, imm);
+}
+
+int __srli(rv_reg rd, rv_reg rs1, int imm)
+{
+    return rv_encode_I(rv_srli, rd, rs1, imm);
+}
+
+int __srai(rv_reg rd, rv_reg rs1, int imm)
+{
+    return rv_encode_I(rv_srai, rd, rs1, imm);
+}
+
+int __slti(rv_reg rd, rv_reg rs1, int imm)
+{
+    return rv_encode_I(rv_slti, rd, rs1, imm);
+}
+
+int __sltiu(rv_reg rd, rv_reg rs1, int imm)
+{
+    return rv_encode_I(rv_sltiu, rd, rs1, imm);
+}
+
+int __lb(rv_reg rd, rv_reg rs1, int imm)
+{
+    return rv_encode_I(rv_lb, rd, rs1, imm);
+}
+
+int __lh(rv_reg rd, rv_reg rs1, int imm)
+{
+    return rv_encode_I(rv_lh, rd, rs1, imm);
+}
+
+int __lw(rv_reg rd, rv_reg rs1, int imm)
+{
+    return rv_encode_I(rv_lw, rd, rs1, imm);
+}
+
+int __lbu(rv_reg rd, rv_reg rs1, int imm)
+{
+    return rv_encode_I(rv_lbu, rd, rs1, imm);
+}
+
+int __lhu(rv_reg rd, rv_reg rs1, int imm)
+{
+    return rv_encode_I(rv_lhu, rd, rs1, imm);
+}
+
+int __sb(rv_reg rd, rv_reg rs1, int imm)
+{
+    return rv_encode_S(rv_sb, rs1, rd, imm);
+}
+
+int __sh(rv_reg rd, rv_reg rs1, int imm)
+{
+    return rv_encode_S(rv_sh, rs1, rd, imm);
+}
+
+int __sw(rv_reg rd, rv_reg rs1, int imm)
+{
+    return rv_encode_S(rv_sw, rs1, rd, imm);
+}
+
+int __beq(rv_reg rs1, rv_reg rs2, int imm)
+{
+    return rv_encode_B(rv_beq, rs1, rs2, imm);
+}
+
+int __bne(rv_reg rs1, rv_reg rs2, int imm)
+{
+    return rv_encode_B(rv_bne, rs1, rs2, imm);
+}
+
+int __blt(rv_reg rs1, rv_reg rs2, int imm)
+{
+    return rv_encode_B(rv_blt, rs1, rs2, imm);
+}
+
+int __bge(rv_reg rs1, rv_reg rs2, int imm)
+{
+    return rv_encode_B(rv_bge, rs1, rs2, imm);
+}
+
+int __bltu(rv_reg rs1, rv_reg rs2, int imm)
+{
+    return rv_encode_B(rv_bltu, rs1, rs2, imm);
+}
+
+int __bgeu(rv_reg rs1, rv_reg rs2, int imm)
+{
+    return rv_encode_B(rv_bgeu, rs1, rs2, imm);
+}
+
+int __jal(rv_reg rd, int imm)
+{
+    return rv_encode_J(rv_jal, rd, imm);
+}
+
+int __jalr(rv_reg rd, rv_reg rs1, int imm)
+{
+    return rv_encode_I(rv_jalr, rd, rs1, imm);
+}
+
+int __lui(rv_reg rd, int imm)
+{
+    return rv_encode_U(rv_lui, rd, imm);
+}
+
+int __auipc(rv_reg rd, int imm)
+{
+    return rv_encode_U(rv_auipc, rd, imm);
+}
+
+int __ecall()
+{
+    return rv_encode_I(rv_ecall, __zero, __zero, 0);
+}
+
+int __ebreak()
+{
+    return rv_encode_I(rv_ebreak, __zero, __zero, 1);
+}
+
+int __nop()
+{
+    return __addi(__zero, __zero, 0);
+}
+
+int __mul(rv_reg rd, rv_reg rs1, rv_reg rs2)
+{
+    return rv_encode_R(rv_mul, rd, rs1, rs2);
+}
+
+int __div(rv_reg rd, rv_reg rs1, rv_reg rs2)
+{
+    return rv_encode_R(rv_div, rd, rs1, rs2);
+}
+
+int __mod(rv_reg rd, rv_reg rs1, rv_reg rs2)
+{
+    return rv_encode_R(rv_mod, rd, rs1, rs2);
+}


### PR DESCRIPTION
This patch rework risc-v backend by fixing several bugs and adding
several new features

Fix:
- Inproper value return from main function
- Wrong length of B-type instruction
- Fail to import built-in libc
- Can't open file
- Can't pass stage2 ,bootstrap and driver.sh

Add:
- xor
- bit not
- mod
- div