### PR TITLE
Upgrade Travis-CI env to Ubuntu 20.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - linux
 
 dist:
-  - bionic
+  - focal
 
 compiler:
   - gcc


### PR DESCRIPTION
`qemu-user` under Ubuntu 18.04 in Travis-CI doesn't support `qemu-riscv32`, as
a result, we upgrade it to Ubuntu 20.04 (focal)