### PR TITLE
Support function pointer

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,6 @@ int fib(int n)      fib:                        Reserve stack frame for function
 4. The support of varying number of function arguments is incomplete. No `<stdarg.h>` can be used.
    Alternatively, check the implementation `printf` in source `lib/c.c` for `var_arg`.
 7. The C front-end is a bit dirty because there is no effective AST.
-8. No function pointer is supported.
 
 ## License
 

--- a/src/arm.c
+++ b/src/arm.c
@@ -258,6 +258,11 @@ int __bl(arm_cond_t cond, int ofs)
     return arm_encode(cond, 176, 0, 0, 0) + (o & 16777215);
 }
 
+int __blx(arm_cond_t cond, arm_reg rd)
+{
+    return arm_encode(cond, 18, 15, 15, rd + 3888);
+}
+
 int __mul(arm_cond_t cond, arm_reg rd, arm_reg r1, arm_reg r2)
 {
     return arm_encode(cond, 0, rd, 0, (r1 << 8) + 144 + r2);

--- a/src/defs.h
+++ b/src/defs.h
@@ -40,6 +40,7 @@ typedef enum {
     OP_func_extry, /* function entry point */
     OP_exit,       /* program exit routine */
     OP_call,       /* function call */
+    OP_indirect,   /* indirect call with function pointer */
     OP_func_exit,  /* function exit code */
     OP_return,     /* jump to function exit */
 
@@ -109,6 +110,7 @@ typedef struct {
     char type_name[MAX_TYPE_LEN];
     char var_name[MAX_VAR_LEN];
     int is_ptr;
+    int is_func;
     int array_size;
     int offset;   /* offset from stack or frame */
     int init_val; /* for global initialization */

--- a/src/globals.c
+++ b/src/globals.c
@@ -187,7 +187,7 @@ int size_var(var_t *var)
 {
     int s = 0;
 
-    if (var->is_ptr > 0) {
+    if (var->is_ptr > 0 || var->is_func > 0) {
         s += 4;
     } else {
         type_t *td = find_type(var->type_name);

--- a/tests/driver.sh
+++ b/tests/driver.sh
@@ -223,6 +223,23 @@ int main() {
 }
 EOF
 
+# function pointers
+try_ 18 << EOF
+typedef struct {
+    int (*ta)();
+    int (*tb)(int);
+} fptrs;
+int t1() { return 7; }
+int t2(int x) { return x + 1; }
+int main() {
+    fptrs fb;
+    fptrs *fs = &fb;
+    fs->ta = t1;
+    fs->tb = t2;
+    return fs->ta() + fs->tb(10);
+}
+EOF
+
 # arrays
 try_ 12 << EOF
 int nth_of(int *a, int i) {


### PR DESCRIPTION
This patch introduced indirect function call, which is required by
function pointers. New opcode "OP_indirect" appears in IR, and both Arm
and RISC-V implementations are implemented accordingly.

Later, we can even encapsulate the target-specific code generations with
function pointers, that means no duplicated "codegen.c" file.