### PR TITLE
Refactor architecture specific configurations

### DIFF
--- a/mk/arm.mk
+++ b/mk/arm.mk
@@ -6,3 +6,11 @@ ARM_EXEC = echo WARN: unable to run
 endif
 
 export ARM_EXEC
+
+arm-specific-defs = \
+    $(Q)$(PRINTF) \
+" /* target: ARM */\n\
+  \#define ARCH_PREDEFINED \"__arm__\" /* defined by GNU C and RealView */\n\
+  \#define ELF_MACHINE 0x28 /* up to ARMv7/Aarch32 */\n\
+  \#define ELF_FLAGS 0x5000200\n\
+"

--- a/mk/riscv.mk
+++ b/mk/riscv.mk
@@ -6,3 +6,11 @@ RISCV_EXEC = echo WARN: unable to run
 endif
 
 export RISCV_EXEC
+
+riscv-specific-defs = \
+    $(Q)$(PRINTF) \
+" /* target: RISCV */\n\
+  \#define ARCH_PREDEFINED \"__riscv\" /* Older versions of the GCC toolchain defined __riscv__ */\n\
+  \#define ELF_MACHINE 0xf3\n\
+  \#define ELF_FLAGS 0\n\
+"

--- a/src/cfront.c
+++ b/src/cfront.c
@@ -2168,15 +2168,8 @@ void parse_internal()
     add_block(NULL, NULL);    /* global block */
     elf_add_symbol("", 0, 0); /* undef symbol */
 
-/* architecture defines */
-/* FIXME: use #ifdef ... #else ... #endif */
-#ifdef TARGET_ARM
-    add_alias("__arm__", "1"); /* defined by GNU C and RealView */
-#endif
-#ifdef TARGET_RISCV
-    /* Older versions of the GCC toolchain defined __riscv__ */
-    add_alias("__riscv", "1");
-#endif
+    /* architecture defines */
+    add_alias(ARCH_PREDEFINED, "1");
 
     /* binary entry point: read params, call main, exit */
     ii = add_instr(OP_label);

--- a/src/elf.c
+++ b/src/elf.c
@@ -82,13 +82,7 @@ void elf_generate_header()
     elf_write_header_int(0);          /* EI_PAD: unused */
     elf_write_header_byte(2);         /* ET_EXEC */
     elf_write_header_byte(0);
-/* FIXME: use #ifdef ... #else ... #endif */
-#ifdef TARGET_ARM
-    elf_write_header_byte(0x28); /* ARM (up to ARMv7/Aarch32) */
-#endif
-#ifdef TARGET_RISCV
-    elf_write_header_byte(0xf3); /* RISC-V */
-#endif
+    elf_write_header_byte(ELF_MACHINE);
     elf_write_header_byte(0);
     elf_write_header_int(1);                          /* ELF version */
     elf_write_header_int(ELF_START + elf_header_len); /* entry point */
@@ -96,14 +90,8 @@ void elf_generate_header()
     elf_write_header_int(elf_header_len + elf_code_idx + elf_data_idx + 39 +
                          elf_symtab_index +
                          elf_strtab_index); /* section header offset */
-/* flags */
-/* FIXME: use #ifdef ... #else ... #endif */
-#ifdef TARGET_ARM
-    elf_write_header_int(0x5000200); /* ARM */
-#endif
-#ifdef TARGET_RISCV
-    elf_write_header_int(0);
-#endif
+    /* flags */
+    elf_write_header_int(ELF_FLAGS);
     elf_write_header_byte(0x34); /* header size */
     elf_write_header_byte(0);
     elf_write_header_byte(0x20); /* program header size */

--- a/tests/driver.sh
+++ b/tests/driver.sh
@@ -10,11 +10,10 @@ function try() {
 
     local tmp_in="$(mktemp --suffix .c)"
     local tmp_exe="$(mktemp)"
-    local target_exec=$(<"$PWD/out/target")
     echo "$input" > "$tmp_in"
     "$SHECC" -o "$tmp_exe" "$tmp_in"
     chmod +x $tmp_exe
-    $target_exec "$tmp_exe"
+    $TARGET_EXEC "$tmp_exe"
     local actual="$?"
 
     if [ "$actual" = "$expected" ]; then


### PR DESCRIPTION
In local, it works fine for testing command in `travis.yml`:

```
make config ARCH=arm
make VERBOSE=1      
make check
make clean
make config ARCH=riscv
make VERBOSE=1
make check
sh .ci/check-format.sh
```
I'm not sure if it's bug of Travis-CI's or mine.
