### PR TITLE
Improve format specifiers

### DIFF
--- a/lib/c.c
+++ b/lib/c.c
@@ -153,7 +153,6 @@ void __str_base10(char *pb, int val)
     }
 }
 
-
 void __str_base8(char *pb, int val)
 {
     int c = INT_BUF_LEN - 1;
@@ -193,17 +192,24 @@ int __format(char *buffer,
     int pbi = 0;
 
     if (alternate_form == 1) {
-        if (base == 8) {
+        switch (base) {
+        case 8:
             /* octal */
             buffer[0] = '0';
             bi = 1;
             width -= 1;
-        } else if (base == 16) {
+            break;
+        case 16:
             /* hex */
             buffer[0] = '0';
             buffer[1] = 'x';
             bi = 2;
             width -= 2;
+            break;
+        default:
+            /* decimal */
+            /* do nothing */
+            break;
         }
         if (width < 0)
             width = 0;
@@ -215,14 +221,19 @@ int __format(char *buffer,
         pbi++;
     }
 
-    if (base == 10)
-        __str_base10(pb, val);
-    else if (base == 8)
+    switch (base) {
+    case 8:
         __str_base8(pb, val);
-    else if (base == 16)
+        break;
+    case 10:
+        __str_base10(pb, val);
+        break;
+    case 16:
         __str_base16(pb, val);
-    else
+        break;
+    default:
         abort();
+    }
 
     while (width > INT_BUF_LEN) {
         /* need to add extra padding */

--- a/lib/c.c
+++ b/lib/c.c
@@ -279,7 +279,7 @@ void printf(char *str, ...)
             if (str[si] >= '1' && str[si] <= '9') {
                 w = str[si] - '0';
                 si++;
-                if (str[si] >= '0' && str[si] <= '9') {
+                while (str[si] >= '0' && str[si] <= '9') {
                     w = w * 10;
                     w += str[si] - '0';
                     si++;
@@ -302,6 +302,11 @@ void printf(char *str, ...)
                 /* append param as hex */
                 int v = var_args[pi];
                 bi += __format(buffer + bi, v, w, zp, 16, pp);
+            } else if (str[si] == '%') {
+                /* append literal '%' character */
+                buffer[bi] = '%';
+                bi++;
+                pi++;
             }
             pi--;
             si++;

--- a/tests/driver.sh
+++ b/tests/driver.sh
@@ -430,4 +430,18 @@ int main() {
 }
 EOF
 
+try_output 0 "$(printf '%97s123')" << EOF
+int main() {
+    printf("%100d", 123);
+    return 0;
+}
+EOF
+
+try_output 0 "%1" << EOF
+int main() {
+    printf("%%%d", 1);
+    return 0;
+}
+EOF
+
 echo OK

--- a/tests/driver.sh
+++ b/tests/driver.sh
@@ -444,4 +444,32 @@ int main() {
 }
 EOF
 
+try_output 0 "144" << EOF
+int main() {
+    printf("%o", 100);
+    return 0;
+}
+EOF
+
+try_output 0 "0144" << EOF
+int main() {
+    printf("%#o", 100);
+    return 0;
+}
+EOF
+
+try_output 0 "7f" << EOF
+int main() {
+    printf("%x", 127);
+    return 0;
+}
+EOF
+
+try_output 0 "0x7f" << EOF
+int main() {
+    printf("%#x", 127);
+    return 0;
+}
+EOF
+
 echo OK


### PR DESCRIPTION
In padding section of format function, use to pad less than 100(10^2) character. And add support of "%%" format, which simply print '%' character.