### PR TITLE
Fix incorrect usage of printf

### DIFF
--- a/src/globals.c
+++ b/src/globals.c
@@ -389,7 +389,7 @@ hashmap_node_t *hashmap_node_new(char *key, void *val)
     node->key = calloc(len + 1, sizeof(char));
 
     if (!node->key) {
-        printf("Failed to allocate hashmap_node_t key with size %d\n");
+        printf("Failed to allocate hashmap_node_t key with size %d\n", len + 1);
         free(node);
         return NULL;
     }


### PR DESCRIPTION
This fixes potential invalid pointer dereference when fails to allocate.  
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request fixes a bug in the `src/globals.c` file by correcting the usage of the `printf` function. The update ensures that the error message accurately reflects the size of the allocation during memory allocation failures, mitigating potential invalid pointer dereference issues.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>