### PR TITLE
Implement arena memory compaction

### DIFF
--- a/src/defs.h
+++ b/src/defs.h
@@ -47,6 +47,19 @@
 #define DEFAULT_FUNCS_SIZE 64
 #define DEFAULT_INCLUSIONS_SIZE 16
 
+/* Arena compaction bitmask flags for selective memory reclamation */
+#define COMPACT_ARENA_BLOCK 0x01   /* BLOCK_ARENA - variables/blocks */
+#define COMPACT_ARENA_INSN 0x02    /* INSN_ARENA - instructions */
+#define COMPACT_ARENA_BB 0x04      /* BB_ARENA - basic blocks */
+#define COMPACT_ARENA_HASHMAP 0x08 /* HASHMAP_ARENA - hash nodes */
+#define COMPACT_ARENA_GENERAL 0x10 /* GENERAL_ARENA - misc allocations */
+#define COMPACT_ARENA_ALL 0x1F     /* All arenas */
+
+/* Common arena compaction combinations for different compilation phases */
+#define COMPACT_PHASE_PARSING (COMPACT_ARENA_BLOCK | COMPACT_ARENA_GENERAL)
+#define COMPACT_PHASE_SSA (COMPACT_ARENA_INSN | COMPACT_ARENA_BB)
+#define COMPACT_PHASE_BACKEND (COMPACT_ARENA_BB | COMPACT_ARENA_GENERAL)
+
 #define ELF_START 0x10000
 #define PTR_SIZE 4
 


### PR DESCRIPTION
This commit adds arena compaction mechanism that safely reclaims memory by freeing trailing empty blocks after compilation phases, reducing memory usage by 1200 KiB typically. 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request introduces an arena memory compaction mechanism that improves memory management by reclaiming memory from trailing empty blocks after compilation. It includes new compaction flags, functions for execution, and integration into the compilation workflow, aiming to reduce memory usage by approximately 1200 KiB.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>