### PR TITLE
Fix pointer arithmetic for all pointer types

### DIFF
--- a/src/arm.c
+++ b/src/arm.c
@@ -230,8 +230,12 @@ int __sll_amt(arm_cond_t cond,
 
 int __sra(arm_cond_t cond, arm_reg rd, arm_reg rm, arm_reg rs)
 {
+    /* Arithmetic right shift with register
+     * Bit 4 = 1 (register-specified shift)
+     * Bits 5-6 = arith_rs (2) for arithmetic right shift
+     */
     return arm_encode(cond, 0 + (arm_mov << 1) + (0 << 5), 0, rd,
-                      rm + (5 << 4) + (rs << 8));
+                      rm + (1 << 4) + (arith_rs << 5) + (rs << 8));
 }
 
 int __add_i(arm_cond_t cond, arm_reg rd, arm_reg rs, int imm)


### PR DESCRIPTION
This commit resolves the long-standing limitation where non-char pointer differences didn't work correctly. The root cause was incorrect ARM instruction encoding for arithmetic right shift, not a parser issue.

The fix enables proper pointer differences for all types:
- Integer pointers (int*)
- Struct pointers
- Typedef pointers
- Complex pointer expressions
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes pointer arithmetic across all pointer types by correcting ARM SRA encoding and unifying pointer arithmetic in the parser. Pointer differences now return element counts for int*, struct*, typedef pointers, and complex expressions.

- **Bug Fixes**
  - Corrected ARM arithmetic right shift (register-based) instruction encoding.
  - Unified pointer arithmetic: detects pointer–pointer difference, scales by element size, and preserves pointer type metadata.
  - Expanded tests to cover int/char/struct/typedef pointers, negative and zero differences, array indexing, and complex expressions.

<!-- End of auto-generated description by cubic. -->

