### PR TITLE
Cleanup stale TODO comments

### DIFF
--- a/src/ssa.c
+++ b/src/ssa.c
@@ -903,8 +903,6 @@ void bb_unwind_phi(func_t *func, basic_block_t *bb)
         for (phi_operand_t *operand = insn->phi_ops; operand;
              operand = operand->next)
             append_unwound_phi_insn(operand->from, insn->rd, operand->var);
-        /* TODO: Release memory allocated for phi instruction to prevent leaks
-         */
     }
 
     bb->insn_list.head = insn;


### PR DESCRIPTION
Phi instructions in SSA unit is previously allocated via builtin
malloc, and wasn't freeing after SSA unit completed. Later, we
replaced allocator with arena allocator, which guaranteed its lifetime
is within the compilation, thus the TODO comment is removed as resolved.

Close #275.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Enable LeakSanitizer in the sanitizer build to catch memory leaks during compiler tests. Adds -fsanitize=leak to CFLAGS/LDFLAGS and removes a stale TODO about freeing SSA phi instruction memory.

<!-- End of auto-generated description by cubic. -->

