### PR TITLE
Fix a crash when reporting an error at the end of a file

### DIFF
--- a/src/globals.c
+++ b/src/globals.c
@@ -1395,7 +1395,8 @@ void error(char *msg)
     start_idx = offset + 1;
 
     for (offset = 0;
-         offset < MAX_SOURCE && SOURCE->elements[start_idx + offset] != '\n';
+         offset < MAX_SOURCE && (start_idx + offset) < SOURCE->size &&
+         SOURCE->elements[start_idx + offset] != '\n';
          offset++) {
         diagnostic[i++] = SOURCE->elements[start_idx + offset];
     }


### PR DESCRIPTION
The compiler crashes with a segmentation fault when an unterminated C-style comment exists at the very end of a file.

The root cause is a buffer over-read in the error() function, which attempts to construct a diagnostic message by reading the source line containing the error. When the error is on the last line of a file without a trailing newline, this logic would read past the end of the source buffer.

Fix the issue by adding a bounds check to the loop, ensuring it does not read beyond the source buffer's size. This allows the compiler to correctly report the "Unenclosed C-style comment" error instead of crashing.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Prevents a crash when reporting an error at EOF by adding a source-bounds check while building the diagnostic line. Unterminated C-style comments at the end of a file without a trailing newline now produce a proper error instead of a segfault.

- **Bug Fixes**
  - Add bounds check in error() to avoid reading past SOURCE->size when scanning for newline in src/globals.c.

<!-- End of auto-generated description by cubic. -->

