### PR TITLE
Fix wrong op match in peephole optimization

### DIFF
--- a/src/peephole.c
+++ b/src/peephole.c
@@ -684,7 +684,7 @@ bool bitwise_optimization(ph2_ir_t *ph2_ir)
     /* Pattern 1: Double complement → identity
      * ~(~x) = x
      */
-    if (ph2_ir->op == OP_negate && next->op == OP_negate &&
+    if (ph2_ir->op == OP_bit_not && next->op == OP_bit_not &&
         next->src0 == ph2_ir->dest) {
         /* Replace with simple assignment */
         ph2_ir->op = OP_assign;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the peephole optimization to correctly detect and fold a double bitwise NOT. The rule now reduces ~(~x) to x without hitting the arithmetic negate path.

- **Bug Fixes**
  - Match OP_bit_not (not OP_negate) for the "~(~x) => x" rule to prevent incorrect transforms.

<sup>Written for commit 32ba47ab831e46a9b9b3f58717b7cad345ff7264. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

