### PR TITLE
Fix error in constant evaluation optimization

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -3513,9 +3513,14 @@ int eval_expression_imm(opcode_t op, int op1, int op2)
         res = op1 * op2;
         break;
     case OP_div:
+        if (!op2)
+            error_at("Division by zero in constant expression",
+                     cur_token_loc());
         res = op1 / op2;
         break;
     case OP_mod:
+        if (!op2)
+            error_at("Modulo by zero in constant expression", cur_token_loc());
         /* Use bitwise AND for modulo optimization when divisor is power of 2 */
         if (tmp == INT_MIN) {
             res = op1 % op2;

--- a/src/parser.c
+++ b/src/parser.c
@@ -4,6 +4,7 @@
  * shecc is freely redistributable under the BSD 2 clause license. See the
  * file "LICENSE" for information on usage and redistribution of this file.
  */
+#include <limits.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -3516,12 +3517,20 @@ int eval_expression_imm(opcode_t op, int op1, int op2)
         break;
     case OP_mod:
         /* Use bitwise AND for modulo optimization when divisor is power of 2 */
-        tmp &= (tmp - 1);
-        if ((op2 != 0) && (tmp == 0)) {
-            res = op1;
-            res &= (op2 - 1);
-        } else
+        if (tmp == INT_MIN) {
             res = op1 % op2;
+            break;
+        }
+        tmp = tmp < 0 ? -tmp : tmp;
+        tmp &= (tmp - 1);
+        if (tmp != 0) {
+            res = op1 % op2;
+            break;
+        }
+        op2 = op2 < 0 ? -op2 : op2;
+        res = op1 & (op2 - 1);
+        if (op1 < 0 && res != 0)
+            res -= op2;
         break;
     case OP_lshift:
         res = op1 << op2;

--- a/tests/driver.sh
+++ b/tests/driver.sh
@@ -420,6 +420,16 @@ int main() {
 }
 EOF
 
+try_compile_error << EOF
+int value = 1 / 0;
+int main() { return value; }
+EOF
+
+try_compile_error << EOF
+int value = 1 % 0;
+int main() { return value; }
+EOF
+
 # Category: Overflow Behavior
 begin_category "Overflow Behavior" "Testing integer overflow handling"
 

--- a/tests/driver.sh
+++ b/tests/driver.sh
@@ -409,6 +409,17 @@ declare -a arithmetic_tests=(
 run_expr_tests arithmetic_tests
 expr 6 "111 % 7"
 
+try_output 0 "1 1 -1 -1" << EOF
+int v1 = 5 % 4;
+int v2 = 5 % -4;
+int v3 = -5 % 4;
+int v4 = -5 % -4;
+int main() {
+    printf("%d %d %d %d", v1, v2, v3, v4);
+    return 0;
+}
+EOF
+
 # Category: Overflow Behavior
 begin_category "Overflow Behavior" "Testing integer overflow handling"
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix constant expression evaluation for division and modulo. We now diagnose zero divisors and compute signed modulo correctly (including the power-of-two fast path and INT_MIN), so compile-time results and global initializers match C semantics.

- **Bug Fixes**
  - Reject division/modulo by zero through the parser error path; add compile-error tests.
  - Correct signed modulo for power-of-two divisors and negative operands; handle INT_MIN safely; add regression tests for all sign combinations.

<sup>Written for commit 0f68934b0ce73339ff7771ce0fcb90b426a08112. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/shecc/pull/324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

